### PR TITLE
Dockerize paper hacker news

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:14.12
+
+RUN apt-get update
+RUN npm install http-server -g
+RUN git clone https://github.com/wolfgang42/paper-hn.git
+
+WORKDIR /paper-hn
+RUN yarn install
+
+COPY /scripts/main_loop.sh .
+
+CMD /paper-hn/main_loop.sh

--- a/scripts/main_loop.sh
+++ b/scripts/main_loop.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+cd /paper-hn
+
+http-server . >http.log 2>&1 &
+echo Starting up... > index.html
+
+while true
+do
+    node --experimental-modules ./bin/generate-html.mjs    
+    sleep 60
+    rm cache/hn/*.json
+done
+

--- a/scripts/main_loop.sh
+++ b/scripts/main_loop.sh
@@ -8,7 +8,7 @@ echo Starting up... > index.html
 while true
 do
     node --experimental-modules ./bin/generate-html.mjs    
-    sleep 60
+    sleep 300
     rm cache/hn/*.json
 done
 

--- a/scripts/main_loop.sh
+++ b/scripts/main_loop.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+
+REFRESH_INTERVAL=${REFRESH_INTERVAL:-300}
 cd /paper-hn
 
 http-server . >http.log 2>&1 &
@@ -8,7 +10,7 @@ echo Starting up... > index.html
 while true
 do
     node --experimental-modules ./bin/generate-html.mjs    
-    sleep 300
+    sleep $REFRESH_INTERVAL
     rm cache/hn/*.json
 done
 


### PR DESCRIPTION
This PR dockerizes Paper Hacker News for easy distribution and scalability.

Building:
```bash
docker build -t paper-hn .
```

Running (default settings):
```bash
docker run -it -p 8080:8080 paper-hn 
```

Running (specify refresh frequency):
```bash
docker run -it --env "REFRESH_INTERVAL=60" -p 8080:8080 paper-hn
```

Your news are now accessible over at `localhost:8080` in your favorite browser.